### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ['*']  # 触发所有目标分支的 PR
 
+permissions:
+  contents: read
+
 jobs:
   check-and-build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Potential fix for [https://github.com/cmtlyt/tee/security/code-scanning/1](https://github.com/cmtlyt/tee/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents (e.g., to check out the code and install dependencies), we will set `contents: read`. This ensures that the workflow has the minimal permissions required to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
